### PR TITLE
improve test setup scripts by adding missing package

### DIFF
--- a/docs/scripts/prepareUbuntuInstanceForITests.sh
+++ b/docs/scripts/prepareUbuntuInstanceForITests.sh
@@ -6,7 +6,7 @@ set -e
 # by installing the required packages.
 
 apt update
-apt install -y make bash curl gnupg sed tar git nginx fcgiwrap gnutls-bin
+apt install -y make bash curl gnupg sed tar git nginx fcgiwrap gnutls-bin zip
 
 # Install Go from binary distribution
 latest_go="$(curl https://go.dev/VERSION\?m=text| head -1).linux-amd64.tar.gz"


### PR DESCRIPTION
 Add zip as package to be installed in preparation step as the `make dist` target uses it.