### PR TITLE
feat: perform go path repo move

### DIFF
--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt install -y make nginx fcgiwrap gnutls-bin
           cp -r $GITHUB_WORKSPACE ~
           cd ~
-          cd csaf_distribution/docs/scripts/
+          cd csaf/docs/scripts/
           # keep in sync with docs/scripts/Readme.md
           export FOLDERNAME=devca1 ORGANAME="CSAF Tools Development (internal)"
           source ./TLSConfigsForITest.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,5 +24,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
             files: |
-                dist/csaf_distribution-*.zip
-                dist/csaf_distribution-*.tar.gz
+                dist/csaf-*.zip
+                dist/csaf-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 # SPDX-FileCopyrightText: 2021 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 # Software-Engineering: 2021 Intevation GmbH <https://intevation.de>
 #
-# Makefile to build csaf_distribution components
+# Makefile to build csaf components
 
 SHELL = /bin/bash
 BUILD = go build
@@ -59,7 +59,7 @@ testsemver:
 
 
 # Set -ldflags parameter to pass the semversion.
-LDFLAGS = -ldflags "-X github.com/csaf-poc/csaf_distribution/v3/util.SemVersion=$(SEMVER)"
+LDFLAGS = -ldflags "-X github.com/gocsaf/csaf/v3/util.SemVersion=$(SEMVER)"
 
 # Build binaries and place them under bin-$(GOOS)-$(GOARCH)
 # Using 'Target-specific Variable Values' to specify the build target system
@@ -78,7 +78,7 @@ build_linux build_win build_mac_amd64 build_mac_arm64:
 	env GOARCH=$(GOARCH) GOOS=$(GOOS) $(BUILD) -o $(BINDIR) $(LDFLAGS) -v ./cmd/...
 
 
-DISTDIR := csaf_distribution-$(SEMVER)
+DISTDIR := csaf-$(SEMVER)
 dist: build_linux build_win build_mac_amd64 build_mac_arm64
 	mkdir -p dist
 	mkdir -p dist/$(DISTDIR)-windows-amd64/bin-windows-amd64

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 > and redirection will be switched off a few months later.)
 
 
-# csaf_distribution
+# csaf
 
 Implements a [CSAF](https://csaf.io/)
 ([specification v2.0](https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html)
@@ -52,10 +52,10 @@ is a CSAF Aggregator, to list or mirror providers.
 ## Other stuff
 
 ### [examples](./examples/README.md)
-are small examples of how to use `github.com/csaf-poc/csaf_distribution`
+are small examples of how to use `github.com/gocsaf/csaf`
 as an API. Currently this is a work in progress, as usage of this repository
 as a library to access is _not officially supported_, e.g.
-see https://github.com/csaf-poc/csaf_distribution/issues/367 .
+see https://github.com/gocsaf/csaf/issues/367 .
 
 ## Setup
 Binaries for the server side are only available and tested
@@ -81,7 +81,7 @@ Download the binaries from the most recent release assets on Github.
 
 - A recent version of **Go** (1.22+) should be installed. [Go installation](https://go.dev/doc/install)
 
-- Clone the repository `git clone https://github.com/csaf-poc/csaf_distribution.git `
+- Clone the repository `git clone https://github.com/gocsaf/csaf.git `
 
 - Build Go components Makefile supplies the following targets:
 	- Build for GNU/Linux system: `make build_linux`
@@ -110,7 +110,7 @@ For further details of the development process consult our [development page](./
 
 ## License
 
-- `csaf_distribution` is licensed as Free Software under the terms of the [Apache License, Version 2.0](./LICENSES/Apache-2.0.txt).
+- `csaf` is licensed as Free Software under the terms of the [Apache License, Version 2.0](./LICENSES/Apache-2.0.txt).
 
 - See the specific source files
   for details, the license itself can be found in the directory `LICENSES/`.

--- a/cmd/csaf_aggregator/client.go
+++ b/cmd/csaf_aggregator/client.go
@@ -13,7 +13,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 var errNotFound = errors.New("not found")

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -20,12 +20,12 @@ import (
 	"time"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/certs"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/filter"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/models"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/internal/certs"
+	"github.com/gocsaf/csaf/v3/internal/filter"
+	"github.com/gocsaf/csaf/v3/internal/models"
+	"github.com/gocsaf/csaf/v3/internal/options"
+	"github.com/gocsaf/csaf/v3/util"
 	"golang.org/x/time/rate"
 )
 

--- a/cmd/csaf_aggregator/full.go
+++ b/cmd/csaf_aggregator/full.go
@@ -18,8 +18,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type fullJob struct {

--- a/cmd/csaf_aggregator/indices.go
+++ b/cmd/csaf_aggregator/indices.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 const (

--- a/cmd/csaf_aggregator/interim.go
+++ b/cmd/csaf_aggregator/interim.go
@@ -24,8 +24,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type interimJob struct {

--- a/cmd/csaf_aggregator/lazytransaction.go
+++ b/cmd/csaf_aggregator/lazytransaction.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type lazyTransaction struct {

--- a/cmd/csaf_aggregator/lister.go
+++ b/cmd/csaf_aggregator/lister.go
@@ -11,8 +11,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // mirrorAllowed checks if mirroring is allowed.

--- a/cmd/csaf_aggregator/main.go
+++ b/cmd/csaf_aggregator/main.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
+	"github.com/gocsaf/csaf/v3/internal/options"
 
 	"github.com/gofrs/flock"
 )

--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -30,8 +30,8 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // mirrorAllowed checks if mirroring is allowed.

--- a/cmd/csaf_aggregator/processor.go
+++ b/cmd/csaf_aggregator/processor.go
@@ -14,8 +14,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 )

--- a/cmd/csaf_checker/config.go
+++ b/cmd/csaf_checker/config.go
@@ -13,10 +13,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/csaf-poc/csaf_distribution/v3/internal/certs"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/filter"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/models"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
+	"github.com/gocsaf/csaf/v3/internal/certs"
+	"github.com/gocsaf/csaf/v3/internal/filter"
+	"github.com/gocsaf/csaf/v3/internal/models"
+	"github.com/gocsaf/csaf/v3/internal/options"
 )
 
 type outputFormat string

--- a/cmd/csaf_checker/links.go
+++ b/cmd/csaf_checker/links.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type (

--- a/cmd/csaf_checker/main.go
+++ b/cmd/csaf_checker/main.go
@@ -12,7 +12,7 @@ package main
 import (
 	"log"
 
-	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
+	"github.com/gocsaf/csaf/v3/internal/options"
 )
 
 // run uses a processor to check all the given domains or direct urls

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -32,8 +32,8 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"golang.org/x/time/rate"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // topicMessages stores the collected topicMessages for a specific topic.

--- a/cmd/csaf_checker/report.go
+++ b/cmd/csaf_checker/report.go
@@ -18,8 +18,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/models"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/internal/models"
 )
 
 // MessageType is the kind of the message.

--- a/cmd/csaf_checker/reporters.go
+++ b/cmd/csaf_checker/reporters.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type (

--- a/cmd/csaf_checker/roliecheck.go
+++ b/cmd/csaf_checker/roliecheck.go
@@ -15,8 +15,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // identifier consist of document/tracking/id and document/publisher/namespace,

--- a/cmd/csaf_checker/rules.go
+++ b/cmd/csaf_checker/rules.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
+	"github.com/gocsaf/csaf/v3/csaf"
 )
 
 type ruleCondition int

--- a/cmd/csaf_downloader/config.go
+++ b/cmd/csaf_downloader/config.go
@@ -19,10 +19,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/internal/certs"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/filter"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/models"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
+	"github.com/gocsaf/csaf/v3/internal/certs"
+	"github.com/gocsaf/csaf/v3/internal/filter"
+	"github.com/gocsaf/csaf/v3/internal/models"
+	"github.com/gocsaf/csaf/v3/internal/options"
 )
 
 const (

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -33,8 +33,8 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"golang.org/x/time/rate"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type downloader struct {

--- a/cmd/csaf_downloader/forwarder.go
+++ b/cmd/csaf_downloader/forwarder.go
@@ -19,8 +19,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/csaf-poc/csaf_distribution/v3/internal/misc"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/internal/misc"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // failedForwardDir is the name of the special sub folder

--- a/cmd/csaf_downloader/forwarder_test.go
+++ b/cmd/csaf_downloader/forwarder_test.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/internal/options"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 func TestValidationStatusUpdate(t *testing.T) {

--- a/cmd/csaf_downloader/main.go
+++ b/cmd/csaf_downloader/main.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
+	"github.com/gocsaf/csaf/v3/internal/options"
 )
 
 func run(cfg *config, domains []string) error {

--- a/cmd/csaf_provider/actions.go
+++ b/cmd/csaf_provider/actions.go
@@ -26,8 +26,8 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 const dateFormat = time.RFC3339

--- a/cmd/csaf_provider/config.go
+++ b/cmd/csaf_provider/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
+	"github.com/gocsaf/csaf/v3/csaf"
 )
 
 const (

--- a/cmd/csaf_provider/create.go
+++ b/cmd/csaf_provider/create.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // ensureFolders initializes the paths and call functions to create

--- a/cmd/csaf_provider/files.go
+++ b/cmd/csaf_provider/files.go
@@ -13,7 +13,7 @@ import (
 	"crypto/sha512"
 	"os"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 func writeHashedFile(fname, name string, data []byte, armored string) error {

--- a/cmd/csaf_provider/indices.go
+++ b/cmd/csaf_provider/indices.go
@@ -18,7 +18,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 func updateIndex(dir, fname string) error {

--- a/cmd/csaf_provider/main.go
+++ b/cmd/csaf_provider/main.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type options struct {

--- a/cmd/csaf_provider/rolie.go
+++ b/cmd/csaf_provider/rolie.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // mergeCategories merges the given categories into the old ones.

--- a/cmd/csaf_provider/transaction.go
+++ b/cmd/csaf_provider/transaction.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 func doTransaction(

--- a/cmd/csaf_uploader/config.go
+++ b/cmd/csaf_uploader/config.go
@@ -18,8 +18,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
 
-	"github.com/csaf-poc/csaf_distribution/v3/internal/certs"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/options"
+	"github.com/gocsaf/csaf/v3/internal/certs"
+	"github.com/gocsaf/csaf/v3/internal/options"
 )
 
 const (

--- a/cmd/csaf_uploader/main.go
+++ b/cmd/csaf_uploader/main.go
@@ -9,7 +9,7 @@
 // Implements a command line tool that uploads csaf documents to csaf_provider.
 package main
 
-import "github.com/csaf-poc/csaf_distribution/v3/internal/options"
+import "github.com/gocsaf/csaf/v3/internal/options"
 
 func main() {
 	args, cfg, err := parseArgsConfig()

--- a/cmd/csaf_uploader/processor.go
+++ b/cmd/csaf_uploader/processor.go
@@ -26,9 +26,9 @@ import (
 	"github.com/ProtonMail/gopenpgp/v2/constants"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/internal/misc"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/internal/misc"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type processor struct {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 type options struct {

--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // AdvisoryFile constructs the urls of a remote file.

--- a/csaf/models.go
+++ b/csaf/models.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // TLPLabel is the traffic light policy of the CSAF.

--- a/csaf/providermetaloader.go
+++ b/csaf/providermetaloader.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // ProviderMetadataLoader helps load provider-metadata.json from

--- a/csaf/rolie.go
+++ b/csaf/rolie.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 // ROLIEServiceWorkspaceCollectionCategoriesCategory is a category in a ROLIE service collection.

--- a/csaf/summary.go
+++ b/csaf/summary.go
@@ -11,7 +11,7 @@ package csaf
 import (
 	"time"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 const (

--- a/docs/csaf_checker.md
+++ b/docs/csaf_checker.md
@@ -93,7 +93,7 @@ ignorepattern = [".*white.*", ".*red.*"]
 
 The `role` given in the `provider-metadata.json` is not
 yet considered to change the overall result,
-see <https://github.com/csaf-poc/csaf_distribution/issues/221> .
+see <https://github.com/gocsaf/csaf/issues/221> .
 
 If a provider hosts one or more advisories with a TLP level of AMBER or RED, then these advisories must be access protected.
 To check these advisories, authorization can be given via custom headers or certificates.

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -141,5 +141,5 @@ contact_details = "Example Company can be reached at contact_us@example.com, or 
 
 There is an experimental upload interface which works with a web browser.
 It is disabled by default, as there are known issues, notably:
- * https://github.com/csaf-poc/csaf_distribution/issues/43
- * https://github.com/csaf-poc/csaf_distribution/issues/256
+ * https://github.com/gocsaf/csaf/issues/43
+ * https://github.com/gocsaf/csaf/issues/256

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -115,7 +115,7 @@ sudo chmod g+r,o-rwx /etc/csaf/config.toml
 
 Here is a minimal example configuration,
 which you need to customize for a production setup,
-see the [options of `csaf_provider`](https://github.com/csaf-poc/csaf_distribution/blob/main/docs/csaf_provider.md).
+see the [options of `csaf_provider`](https://github.com/gocsaf/csaf/blob/main/docs/csaf_provider.md).
 
 <!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/scripts/setupProviderForITest.sh&lines=94-101) -->
 <!-- The below code snippet is automatically added from ../docs/scripts/setupProviderForITest.sh -->

--- a/docs/scripts/Readme.md
+++ b/docs/scripts/Readme.md
@@ -1,7 +1,7 @@
 Scripts for assisting the Integration tests.
 They were written on Ubuntu 20.04 TLS amd64 and also tested with 24.04 TLS.
 
-- `prepareUbuntuInstanceForITests.sh` installs the required packages for the csaf_distribution integration tests on a naked ubuntu LTS amd64.
+- `prepareUbuntuInstanceForITests.sh` installs the required packages for the csaf integration tests on a naked Ubuntu LTS amd64.
 
 - `TLSConfigsForITest.sh` generates a root CA and webserver cert by running `createRootCAForITest.sh` and `createWebserverCertForITest.sh`
 and configures nginx for serving TLS connections.
@@ -14,11 +14,11 @@ As creating the folders needs to authenticate with the csaf_provider, the config
 
 Calling example (as user with sudo privileges):
 ``` bash
-    curl --fail -O https://raw.githubusercontent.com/csaf-poc/csaf_distribution/main/docs/scripts/prepareUbuntuInstanceForITests.sh
+    curl --fail -O https://raw.githubusercontent.com/gocsaf/csaf/main/docs/scripts/prepareUbuntuInstanceForITests.sh
     sudo bash prepareUbuntuInstanceForITests.sh
 
-    git clone https://github.com/csaf-poc/csaf_distribution.git # --branch <name>
-    pushd csaf_distribution/docs/scripts/
+    git clone https://github.com/gocsaf/csaf.git # --branch <name>
+    pushd csaf/docs/scripts/
 
     export FOLDERNAME=devca1 ORGANAME="CSAF Tools Development (internal)"
     source ./TLSConfigsForITest.sh

--- a/docs/scripts/TLSClientConfigsForITest.sh
+++ b/docs/scripts/TLSClientConfigsForITest.sh
@@ -18,7 +18,7 @@ set -e
 
 NGINX_CONFIG_PATH=/etc/nginx/sites-available/default
 
-cd ~/csaf_distribution/docs/scripts/
+cd ~/csaf/docs/scripts/
 source ./createCCForITest.sh
 
 echo '

--- a/docs/scripts/TLSConfigsForITest.sh
+++ b/docs/scripts/TLSConfigsForITest.sh
@@ -17,7 +17,7 @@ set -e
 
 NGINX_CONFIG_PATH=/etc/nginx/sites-available/default
 
-cd ~/csaf_distribution/docs/scripts/
+cd ~/csaf/docs/scripts/
 ## Create Root CA
 ./createRootCAForITest.sh
 

--- a/docs/scripts/prepareUbuntuInstanceForITests.sh
+++ b/docs/scripts/prepareUbuntuInstanceForITests.sh
@@ -2,7 +2,7 @@
 set -e
 
 # This script prepares a naked Ubuntu LTS amd64
-# for the csaf_distribution integration tests
+# for the csaf integration tests
 # by installing the required packages.
 
 apt update

--- a/docs/scripts/testAggregator.sh
+++ b/docs/scripts/testAggregator.sh
@@ -29,6 +29,6 @@ popd
 echo
 echo '=== run aggregator'
 
-cd ~/csaf_distribution/
+cd ~/csaf/
 sudo cp docs/examples/aggregator.toml /etc/csaf
 sudo ./bin-linux-amd64/csaf_aggregator -c /etc/csaf/aggregator.toml

--- a/docs/scripts/testChecker.sh
+++ b/docs/scripts/testChecker.sh
@@ -11,7 +11,7 @@
 set -e  # to exit if a command in the script fails
 
 echo '==== run checker (twice)'
-cd ~/csaf_distribution
+cd ~/csaf
 
 ./bin-linux-amd64/csaf_checker -f html -o ../checker-results.html --insecure \
   --client_cert ~/devca1/testclient1.crt \

--- a/docs/scripts/testDownloader.sh
+++ b/docs/scripts/testDownloader.sh
@@ -10,7 +10,7 @@
 
 set -e  # to exit if a command in the script fails
 
-cd ~/csaf_distribution
+cd ~/csaf
 
 echo
 echo '==== run downloader (1)'

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # API examples
 
-An experimental example of how to use `github.com/csaf-poc/csaf_distribution`
+An experimental example of how to use `github.com/gocsaf/csaf`
 as a library.
 As usage of the repository as an API is currently a _work in progress_,
 these examples are likely to be changed.

--- a/examples/purls_searcher/main.go
+++ b/examples/purls_searcher/main.go
@@ -1,5 +1,5 @@
 // Package main implements a simple demo program to
-// work with the csaf_distribution library.
+// work with the csaf library.
 package main
 
 import (
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/csaf-poc/csaf_distribution/v3/csaf"
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/util"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/csaf-poc/csaf_distribution/v3
+module github.com/gocsaf/csaf/v3
 
 go 1.22
 

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -15,7 +15,7 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/csaf-poc/csaf_distribution/v3/util"
+	"github.com/gocsaf/csaf/v3/util"
 
 	"github.com/BurntSushi/toml"
 	"github.com/jessevdk/go-flags"


### PR DESCRIPTION
 * Change the go module path from github.com/csaf-poc/csaf_distribution to github.com/gocsaf/csaf.
 * Rename archive for release tarballs.
 * Adjust testing scripts and documentation.

Does the first steps for #579 