### PR TITLE
ensure HTTP requests use proxy env vars

### DIFF
--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -284,6 +284,7 @@ func (c *config) httpClient(p *provider) util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -284,7 +284,7 @@ func (c *config) httpClient(p *provider) util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -430,6 +430,7 @@ func (p *processor) fullClient() util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)
@@ -460,6 +461,7 @@ func (p *processor) basicClient() *http.Client {
 	if p.cfg.Insecure {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy: http.ProxyFromEnvironment,
 		}
 		return &http.Client{Transport: tr}
 	}

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -430,7 +430,7 @@ func (p *processor) fullClient() util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)
@@ -461,7 +461,7 @@ func (p *processor) basicClient() *http.Client {
 	if p.cfg.Insecure {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			Proxy: http.ProxyFromEnvironment,
+			Proxy:           http.ProxyFromEnvironment,
 		}
 		return &http.Client{Transport: tr}
 	}

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -121,7 +121,7 @@ func (d *downloader) httpClient() util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -121,6 +121,7 @@ func (d *downloader) httpClient() util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)

--- a/cmd/csaf_downloader/forwarder.go
+++ b/cmd/csaf_downloader/forwarder.go
@@ -106,6 +106,7 @@ func (f *forwarder) httpClient() util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)

--- a/cmd/csaf_downloader/forwarder.go
+++ b/cmd/csaf_downloader/forwarder.go
@@ -106,7 +106,7 @@ func (f *forwarder) httpClient() util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)

--- a/cmd/csaf_uploader/processor.go
+++ b/cmd/csaf_uploader/processor.go
@@ -51,7 +51,7 @@ func (p *processor) httpClient() *http.Client {
 
 	client.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	return &client

--- a/cmd/csaf_uploader/processor.go
+++ b/cmd/csaf_uploader/processor.go
@@ -51,6 +51,7 @@ func (p *processor) httpClient() *http.Client {
 
 	client.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	return &client


### PR DESCRIPTION
#### **Description**
This merge request resolves [Issue 596](#596)  by ensuring that all HTTP and HTTPS traffic uses the proxy configuration specified in the environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`).

#### **Changes Made**
- Updated all instances of `http.Transport` to include the `Proxy` field:
  ```go
  Proxy: http.ProxyFromEnvironment
  ```
- Ensured compatibility with existing `TLSClientConfig` settings, preserving secure connections.

#### **Motivation**
The issue described in [Issue 596](#596) identified a shortfall where proxy settings were ignored, causing failures in proxied environments. This fix ensures compliance with Go's standard proxy behavior and improves usability for users in corporate or secured networks.

#### **Verification**
1. **Environment Setup**:
   - Configured proxy settings using `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
   - Verified traffic routing through the proxy and bypassing for domains listed in `NO_PROXY`.

2. **Test Cases**:
   - Successful request routing through a proxy server.
   - Proper bypassing of proxy for `NO_PROXY`-listed domains.

#### **Impact**
- Resolves connection issues for users in proxied environments.
- Aligns the application with standard Go behavior for `net/http` proxy handling.

#### **Closes**
Closes [Issue 596](#596).