### PR TITLE
Warn if no remote validator was specified

### DIFF
--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -69,6 +69,8 @@ func run(opts *options, files []string) error {
 				"preparing remote validator failed: %w", err)
 		}
 		defer validator.Close()
+	} else {
+		log.Printf("warn: no remote validator specified")
 	}
 
 	// Select amount level of output for remote validation.

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -127,7 +127,6 @@ func run(opts *options, files []string) error {
 		// Check filename against ID
 		if err := util.IDMatchesFilename(eval, doc, filepath.Base(file)); err != nil {
 			log.Printf("%s: %s.\n", file, err)
-			continue
 		}
 
 		// Validate against remote validator.

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -150,7 +150,7 @@ func run(opts *options, files []string) error {
 	}
 
 	// Exit code is based on validation results
-	os.Exit(exitCodeAllValid)
+	os.Exit(exitCode)
 	return nil
 }
 

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	exitCodeAllValid               = 0
-	exitCodeSchemaInvalid          = 1 << 0
-	exitCodeNoRemoteValidator      = 1 << 1
-	exitCodeFailedRemoteValidation = 1 << 2
+	exitCodeSchemaInvalid = 1 << iota
+	exitCodeNoRemoteValidator
+	exitCodeFailedRemoteValidation
+	exitCodeAllValid = 0
 )
 
 type options struct {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	exitCodeSchemaInvalid = 1 << iota
+	exitCodeSchemaInvalid = 2 << iota
 	exitCodeNoRemoteValidator
 	exitCodeFailedRemoteValidation
 	exitCodeAllValid = 0

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -107,7 +107,7 @@ func run(opts *options, files []string) error {
 			log.Printf("error: loading %q as JSON failed: %v\n", file, err)
 			continue
 		}
-		// Validate agsinst Schema.
+		// Validate against Schema.
 		validationErrs, err := csaf.ValidateCSAF(doc)
 		if err != nil {
 			log.Printf("error: validating %q against schema failed: %v\n",
@@ -124,7 +124,7 @@ func run(opts *options, files []string) error {
 			fmt.Printf("%q passes the schema validation.\n", file)
 		}
 
-		// Check filename agains ID
+		// Check filename against ID
 		if err := util.IDMatchesFilename(eval, doc, filepath.Base(file)); err != nil {
 			log.Printf("%s: %s.\n", file, err)
 			continue

--- a/docs/csaf_validator.md
+++ b/docs/csaf_validator.md
@@ -2,6 +2,13 @@
 
 is a tool to validate local advisories files against the JSON Schema and an optional remote validator.
 
+### Exit codes
+If no fatal error occurs the program will exit with the following codes:
+- `0`: all valid
+- `2⁰`: schema invalid
+- `2¹`: no remote validator configured
+- `2²`: failure in remote validation
+
 ### Usage
 
 ```

--- a/docs/csaf_validator.md
+++ b/docs/csaf_validator.md
@@ -3,11 +3,11 @@
 is a tool to validate local advisories files against the JSON Schema and an optional remote validator.
 
 ### Exit codes
-If no fatal error occurs the program will exit with the following codes:
-- `0`: all valid
-- `2⁰`: schema invalid
-- `2¹`: no remote validator configured
-- `2²`: failure in remote validation
+If no fatal error occurs the program will exit with an exit code `n` with the following conditions:
+- `n == 0`: all valid
+- `(n / 2) % 1 == 1`: schema validation failed
+- `(n / 4) % 1 == 1`: no remote validator configured
+- `(n / 8) % 1 == 1`: failure in remote validation
 
 ### Usage
 

--- a/docs/csaf_validator.md
+++ b/docs/csaf_validator.md
@@ -5,9 +5,10 @@ is a tool to validate local advisories files against the JSON Schema and an opti
 ### Exit codes
 If no fatal error occurs the program will exit with an exit code `n` with the following conditions:
 - `n == 0`: all valid
-- `(n / 2) % 1 == 1`: schema validation failed
-- `(n / 4) % 1 == 1`: no remote validator configured
-- `(n / 8) % 1 == 1`: failure in remote validation
+- `(n & 1) > 0`: general error, see logs
+- `(n & 2) > 0`: schema validation failed
+- `(n & 4) > 0`: no remote validator configured
+- `(n & 8) > 0`: failure in remote validation
 
 ### Usage
 

--- a/docs/csaf_validator.md
+++ b/docs/csaf_validator.md
@@ -3,9 +3,11 @@
 is a tool to validate local advisories files against the JSON Schema and an optional remote validator.
 
 ### Exit codes
+
 If no fatal error occurs the program will exit with an exit code `n` with the following conditions:
+
 - `n == 0`: all valid
-- `(n & 1) > 0`: general error, see logs
+- `(n & 1) > 0`: a general error occurred, all other flags are unset (see logs for more information)
 - `(n & 2) > 0`: schema validation failed
 - `(n & 4) > 0`: no remote validator configured
 - `(n & 8) > 0`: failure in remote validation


### PR DESCRIPTION
Prints a warning if no remote validator was configured.

Closes #601