### PR TITLE
Errors for lookup checks

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -1420,7 +1420,7 @@ func (p *processor) checkWellknownSecurityDNS(domain string) error {
 	p.badSecurity.use()
 
 	// Report about Securitytxt:
-	// Only report about Legacy if default was succesful (0).
+	// Only report about default location if it was succesful (0).
 	// Report default and legacy as errors if neither was succesful (1).
 	// Warn about missing security in the default position if not found
 	// but found in the legacy location, and inform about finding it there (2).


### PR DESCRIPTION
Closes https://github.com/gocsaf/csaf/issues/411

Originally, the checker would fail if any of its checks failed. Since only one of the requirements 8-10 is mandatory, whether one of those checks would give out an error or a warning was dependent on the other two checks and they would only fail if all would fail. 

This no longer holds true for the current design of the checker since c7453a644825ddbb1a5c81a8934a82f2af521630. 

The current design of these three checks lead to e.g. https://github.com/gocsaf/csaf/issues/411, so by modernizing the checkWellknownSecurityDNS function as well as its subfunctions this issue is fixed.