### PR TITLE
update runner for release to 22.04, other actions and go version, thus also newer glibc

### DIFF
--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
             name: checker-results
             path: |

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -7,9 +7,9 @@ jobs:
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.22.0
+          go-version: '^1.23.6'
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -17,7 +17,7 @@ jobs:
           node-version: 16
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Execute the scripts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,23 +7,23 @@ on:
 jobs:
   releases-matrix:
     name: Release Go binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-            go-version: '^1.21.0'
+            go-version: '^1.23.6'
 
       - name: Build
         run: make dist
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
             files: |
                 dist/csaf-*.zip

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Download the binaries from the most recent release assets on Github.
 
 ### Build from sources
 
-- A recent version of **Go** (1.22+) should be installed. [Go installation](https://go.dev/doc/install)
+- A recent version of **Go** (1.23+) should be installed. [Go installation](https://go.dev/doc/install)
 
 - Clone the repository `git clone https://github.com/gocsaf/csaf.git `
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -3,7 +3,7 @@
 ## Supported Go versions
 
 We support the latest version and the one before
-the latest version of Go (currently 1.22 and 1.23).
+the latest version of Go (currently 1.23 and 1.24).
 
 ## Generated files
 


### PR DESCRIPTION
* Update runner to ubuntu-22.04 which is the eldest to be supported
       by github from 2025-04-01.
 * Update github actions and go version for release and itest workflows.
 * Update current go revision to Readme and development docs.

resolve #614
