### PR TITLE
Fix potential leak of HTTP response body in downloadJSON

### DIFF
--- a/cmd/csaf_aggregator/client.go
+++ b/cmd/csaf_aggregator/client.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -20,13 +21,14 @@ var errNotFound = errors.New("not found")
 
 func downloadJSON(c util.Client, url string, found func(io.Reader) error) error {
 	res, err := c.Get(url)
-	if err != nil || res.StatusCode != http.StatusOK ||
+	if err != nil {
+		return fmt.Errorf("not found: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK ||
 		res.Header.Get("Content-Type") != "application/json" {
 		// ignore this as it is expected.
 		return errNotFound
 	}
-	return func() error {
-		defer res.Body.Close()
-		return found(res.Body)
-	}()
+	return found(res.Body)
 }


### PR DESCRIPTION
1. According to standard library the client must close the Body of http response. The function [downloadJSON()](https://github.com/gocsaf/csaf/blob/main/cmd/csaf_aggregator/client.go) in the csaf_aggregator defers the `Body.Close()` after some checks are made and an early return that may return even when `c.Get()` does not return an error. This is where the `res.Body` might not be closed.
2. Besides that either I didn't get the idea behind the return via a call to a closure or it should be simplified.
3. Do not drop the err details from `c.Get()` but give them more context. See Go Blog: _[It is the error implementation’s responsibility to summarize the context.](https://go.dev/blog/error-handling-and-go)_