### PR TITLE
Check if canonical url prefix is valid

### DIFF
--- a/cmd/csaf_provider/config.go
+++ b/cmd/csaf_provider/config.go
@@ -11,6 +11,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -261,6 +262,14 @@ func loadConfig() (*config, error) {
 
 	if cfg.CanonicalURLPrefix == "" {
 		cfg.CanonicalURLPrefix = "https://" + os.Getenv("SERVER_NAME")
+	}
+	// Check if canonical url prefix is invalid
+	parsedURL, err := url.ParseRequestURI(cfg.CanonicalURLPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
+		return nil, fmt.Errorf("invalid canonical URL: %q", cfg.CanonicalURLPrefix)
 	}
 
 	if cfg.TLPs == nil {


### PR DESCRIPTION
This adds a check to the canonical URL prefix configuration. It detects if an error occurs when the user specifies an invalid URL.

This is a breaking change, as an old configuration that worked with the malformed URL is no longer accepted.