### PR TITLE
Remove golint github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,9 +30,6 @@ jobs:
         with:
           gofmt-flags: "-l -d"
 
-      - name: golint
-        uses: Jerome1337/golint-action@v1.0.3
-
       - name: Revive Action
         uses: morphy2k/revive-action@v2.7.4
 


### PR DESCRIPTION
We use Revive already which is a replacement for golint and golint isn't maintained anyway.