### PR TITLE
improve docs (minor) for csaf_provider

### DIFF
--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -58,7 +58,8 @@ The following example file documents all available configuration options:
 # The following shows an example of a manually set prefix:
 #canonical_url_prefix  = "https://localhost"
 
-# Require users to use a password and a valid Client Certificate for write access.
+# Require users to use both
+# (1) a password and (2) a valid Client Certificate for write access.
 #certificate_and_password = false
 
 # Allow the user to send the request without having to send a passphrase


### PR DESCRIPTION
 * add a "both" to explain the config file option `certificate_and_password` better.

Here is the code that shows that it works like this for easier reviewing: https://github.com/gocsaf/csaf/blob/ae184eb189e15c179e2ba618f21d3ae72363222b/cmd/csaf_provider/controller.go#L97-L103

apply after #667 