### PR TITLE
fix doc comment: remove untrue claim of disallowing unknown fields

### DIFF
--- a/internal/misc/json.go
+++ b/internal/misc/json.go
@@ -15,7 +15,7 @@ import (
 )
 
 // StrictJSONParse creates a JSON decoder that decodes an interface
-// while not allowing unknown fields nor trailing data
+// while not allowing trailing data
 func StrictJSONParse(jsonData io.Reader, target any) error {
 	decoder := json.NewDecoder(jsonData)
 


### PR DESCRIPTION
Fix doc comment: remove untrue claim of disallowing unknown json fields in helper function.

Looks like a bug otherwise, but is the intended behavior: 

See commit https://github.com/gocsaf/csaf/pull/655/commits/7935818600ee70cbcb7784a67788a4f3bacaba01 of PR #655 .