### PR TITLE
Re-add unknown fields check

### DIFF
--- a/internal/misc/json.go
+++ b/internal/misc/json.go
@@ -18,6 +18,8 @@ import (
 // while not allowing unknown fields nor trailing data
 func StrictJSONParse(jsonData io.Reader, target any) error {
 	decoder := json.NewDecoder(jsonData)
+	// Don't allow unknown fields
+	decoder.DisallowUnknownFields()
 
 	if err := decoder.Decode(target); err != nil {
 		return fmt.Errorf("JSON decoding error: %w", err)


### PR DESCRIPTION
Re-add the unknown fields check. Will supersede https://github.com/gocsaf/csaf/pull/677

Explanation:

Original comment https://github.com/gocsaf/csaf/pull/677#issue-3393355709 was referring to was based on a misunderstanding. 

From my current understanding, https://docs.oasis-open.org/csaf/csaf/v2.0/cs02/csaf-v2.0-cs02.html#6220-additional-properties specifies additional properties are not allowed.

The reason this was not changed within the code was that additional properties are already flagged during the JSON-schema check and would already lead to an error even if not checked there again.

However, it should be checked here.