### PR TITLE
csaf_downloader - memory leak

### DIFF
--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -360,6 +360,7 @@ func (d *downloader) loadOpenPGPKeys(
 				"url", u,
 				"status_code", res.StatusCode,
 				"status", res.Status)
+			res.Body.Close()
 			continue
 		}
 
@@ -422,7 +423,6 @@ func (d *downloader) logValidationIssues(url string, errors []string, err error)
 type downloadContext struct {
 	d                  *downloader
 	client             util.ClientWithContext
-	data               bytes.Buffer
 	lastDir            string
 	initialReleaseDate time.Time
 	dateExtract        func(any) error
@@ -541,9 +541,11 @@ func (dc *downloadContext) downloadAdvisory(
 		writers = append(writers, s256)
 	}
 
-	// Remember the data as we need to store it to file later.
-	dc.data.Reset()
-	writers = append(writers, &dc.data)
+	// Remember the data as we need to store it to file later. Keep the
+	// buffer local to this advisory so workers do not retain the largest
+	// advisory backing array for the rest of a long-running download.
+	var data bytes.Buffer
+	writers = append(writers, &data)
 
 	// Download the advisory and hash it.
 	hasher := io.MultiWriter(writers...)
@@ -591,7 +593,7 @@ func (dc *downloadContext) downloadAdvisory(
 				"error", err)
 		}
 		if sign != nil {
-			if err := dc.d.checkSignature(dc.data.Bytes(), sign); err != nil {
+			if err := dc.d.checkSignature(data.Bytes(), sign); err != nil {
 				if !dc.d.cfg.IgnoreSignatureCheck {
 					dc.stats.signatureFailed++
 					return fmt.Errorf("cannot verify signature for %s: %v", file.URL(), err)
@@ -663,7 +665,7 @@ func (dc *downloadContext) downloadAdvisory(
 	if dc.d.forwarder != nil {
 		dc.d.forwarder.forward(
 			ctx,
-			filename, dc.data.String(),
+			filename, data.String(),
 			valStatus,
 			string(s256Data),
 			string(s512Data))
@@ -717,7 +719,7 @@ func (dc *downloadContext) downloadAdvisory(
 		p string
 		d []byte
 	}{
-		{path, dc.data.Bytes()},
+		{path, data.Bytes()},
 		{path + ".sha256", s256Data},
 		{path + ".sha512", s512Data},
 		{path + ".asc", signData},

--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -239,12 +239,12 @@ func (afp *AdvisoryFileProcessor) loadChanges(
 		return nil, err
 	}
 
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("fetching %s failed. Status code %d (%s)",
 			changesURL, resp.StatusCode, resp.Status)
 	}
 
-	defer resp.Body.Close()
 	var files []AdvisoryFile
 	c := csv.NewReader(resp.Body)
 	const (
@@ -325,6 +325,7 @@ func (afp *AdvisoryFileProcessor) processROLIE(
 		if res.StatusCode != http.StatusOK {
 			slog.Error("Fetching failed",
 				"url", feedURL, "status_code", res.StatusCode, "status", res.Status)
+			res.Body.Close()
 			continue
 		}
 		rfeed, err := func() (*ROLIEFeed, error) {


### PR DESCRIPTION
Improve CSAF downloader resource management by limiting memory retention and closing HTTP response bodies on failed requests. Advisory data is now buffered locally for each download, preventing long-running workers from retaining the largest previously processed advisory in memory. This reduces memory pressure during large or continuous feed synchronisations and improves cleanup of network resources on error paths.
