### PR TITLE
provider: Add a missing error check when updating index.txt.

### DIFF
--- a/cmd/csaf_provider/indices.go
+++ b/cmd/csaf_provider/indices.go
@@ -44,6 +44,9 @@ func updateIndex(dir, fname string) error {
 				return nil, nil
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			return nil, err
+		}
 		return append(lines, fname), nil
 	}()
 	if err != nil {


### PR DESCRIPTION
When updating an index.txt file in the provider a error check was missing.